### PR TITLE
Stardew Valley 1.4.3 & SMAPI 3.1.0 compatibility

### DIFF
--- a/DailyTasksReport/DailyTasksReport.csproj
+++ b/DailyTasksReport/DailyTasksReport.csproj
@@ -52,7 +52,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.12.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+      <HintPath>..\packages\Newtonsoft.Json.12.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -90,14 +90,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\analyzers\dotnet\cs\SMAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/DailyTasksReport/Tasks/PetTask.cs
+++ b/DailyTasksReport/Tasks/PetTask.cs
@@ -42,6 +42,18 @@ namespace DailyTasksReport.Tasks
             _pet = location.characters.OfType<Pet>().FirstOrDefault();
         }
 
+        private bool IsPetPetted()
+        {
+            if (_pet == null) return false;
+            return _pet.grantedFriendshipForPet.Value;
+        }
+
+        private bool IsPetBowlFilled()
+        {
+            if (_farm == null) return false;
+            return _farm.petBowlWatered.Value;
+        }
+
         private void UpdateInfo()
         {
             if (_pet == null)
@@ -51,8 +63,8 @@ namespace DailyTasksReport.Tasks
                     return;
             }
 
-            _petPetted = ModEntry.ReflectionHelper.GetField<bool>(_pet, "wasPetToday").GetValue();
-            _petBowlFilled = _farm.getTileIndexAt(54, 7, "Buildings") == 1939;
+            _petPetted = IsPetPetted();
+            _petBowlFilled = IsPetBowlFilled();
 
             Enabled = Enabled && !(_petBowlFilled && _petPetted);
         }
@@ -62,7 +74,7 @@ namespace DailyTasksReport.Tasks
             if (!_config.DrawBubbleUnpettedPet || _pet == null || _pet.currentLocation != Game1.currentLocation ||
                 !(Game1.currentLocation is Farm) && !(Game1.currentLocation is FarmHouse)) return;
 
-            _petPetted = ModEntry.ReflectionHelper.GetField<bool>(_pet, "wasPetToday").GetValue();
+            _petPetted = IsPetPetted();
             if (_petPetted) return;
 
             var v = new Vector2(_pet.getStandingX() - Game1.viewport.X - Game1.tileSize * 0.3f,

--- a/DailyTasksReport/manifest.json
+++ b/DailyTasksReport/manifest.json
@@ -5,6 +5,6 @@
 	"Description": "Shows information about some daily tasks in your farm",
 	"UniqueID": "GuiNoya.DailyTasksReport",
 	"EntryDll": "DailyTasksReport.dll",
-	"MinimumApiLevel": "2.10.2",
+	"MinimumApiLevel": "3.1.0",
 	"UpdateKeys": [ "Nexus:1624" ]
 }

--- a/DailyTasksReport/packages.config
+++ b/DailyTasksReport/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="12.0.1" targetFramework="net452" />
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0" targetFramework="net452" />
 </packages>

--- a/SelfServiceShop/ModEntry.cs
+++ b/SelfServiceShop/ModEntry.cs
@@ -125,7 +125,7 @@ namespace SelfServiceShop
                     if (_config.IceCreamStand &&
                         (_config.ShopsAlwaysOpen || _config.IceCreamInAllSeasons || SDate.Now().Season == "summer"))
                     {
-                        var d = new Dictionary<Item, int[]>
+                        var d = new Dictionary<ISalable, int[]>
                         {
                             {new Object(233, 1), new[] {250, int.MaxValue}}
                         };

--- a/SelfServiceShop/SelfServiceShop.csproj
+++ b/SelfServiceShop/SelfServiceShop.csproj
@@ -70,14 +70,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\analyzers\dotnet\cs\SMAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/SelfServiceShop/manifest.json
+++ b/SelfServiceShop/manifest.json
@@ -5,6 +5,6 @@
 	"Description": "Enables you to buy in the shop if no one is at the counter but the owner is at the location",
 	"UniqueID": "GuiNoya.SelfServiceShop",
 	"EntryDll": "SelfServiceShop.dll",
-	"MinimumApiVersion": "2.10.2",
+	"MinimumApiVersion": "3.1.0",
 	"UpdateKeys": [ "Nexus:1622" ]
 }

--- a/SelfServiceShop/packages.config
+++ b/SelfServiceShop/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0" targetFramework="net452" />
 </packages>

--- a/ZoomLevelKeybind/ZoomLevelKeybind.csproj
+++ b/ZoomLevelKeybind/ZoomLevelKeybind.csproj
@@ -69,14 +69,14 @@
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
-    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\analyzers\dotnet\cs\StardewModdingAPI.ModBuildConfig.Analyzer.dll" />
+    <Analyzer Include="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\analyzers\dotnet\cs\SMAPI.ModBuildConfig.Analyzer.dll" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
+  <Import Project="..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets" Condition="Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.2.2.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
+    <Error Condition="!Exists('..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Pathoschild.Stardew.ModBuildConfig.3.0.0\build\Pathoschild.Stardew.ModBuildConfig.targets'))" />
   </Target>
 </Project>

--- a/ZoomLevelKeybind/manifest.json
+++ b/ZoomLevelKeybind/manifest.json
@@ -5,6 +5,6 @@
 	"Description": "Add keybinds to decrease and increase zoom levels",
 	"UniqueID": "GuiNoya.ZoomLevelKeybind",
 	"EntryDll": "ZoomLevelKeybind.dll",
-	"MinimumApiLevel": "2.10.2",
+	"MinimumApiLevel": "3.1.0",
 	"UpdateKeys": [ "Nexus:1621" ]
 }

--- a/ZoomLevelKeybind/packages.config
+++ b/ZoomLevelKeybind/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Pathoschild.Stardew.ModBuildConfig" version="2.2.0" targetFramework="net452" />
+  <package id="Pathoschild.Stardew.ModBuildConfig" version="3.0.0" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Upgrades to SMAPI 3.1.0, and fixes a few bugs to make Stardew Valley 1.4.3 work.

Fixed the bug encountered here: https://community.playstarbound.com/threads/updating-mods-for-stardew-valley-1-4.156000/page-19#post-3353826 - cc @Mizzion

> I got errors running Task Report
> [DailyTasksReport] This mod failed in the GameLoop.DayStarted event. Technical details:
> System.InvalidOperationException: The StardewValley.Characters.Cat object doesn't have a 'wasPetToday' instance field.

Seems like 'wasPetToday' was removed as a property of the Pet in SDV 1.4. I dug around and found that `_pet.grantedFriendshipForPet` does effectively the same thing! Confirmed by attaching Visual Studio debugger and setting a watch-point.

Also, not sure if this was a bug or not, but I did find that you can access `_farm.petBowlWattered` instead of manually probing the water bowl building. Guessing that this will help custom maps work!

This commit was tested on PC for both single- and multi-player and appears to function correctly. I only tested the Daily Tasks report mod, not the other two.